### PR TITLE
Bump Dependency to Fix jdom Vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -47,6 +47,6 @@ libraryDependencies += "org.scala-lang.modules" %% "scala-parser-combinators" % 
 
 libraryDependencies += "commons-io" % "commons-io" % "2.4"
 
-libraryDependencies += "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.22"
+libraryDependencies += "net.sourceforge.htmlcleaner" % "htmlcleaner" % "2.26"
 
 libraryDependencies += "org.specs2" %% "specs2-core" % "4.7.0" % Test


### PR DESCRIPTION
The version of `htmlcleaner` being used uses a vulerable jdom library (according to snyk).

The latest minor version of htmlcleaner bumps the jdom dependency and resolves the jdom vulnerability

https://mvnrepository.com/artifact/net.sourceforge.htmlcleaner/htmlcleaner/2.26

![image](https://user-images.githubusercontent.com/1953161/154138675-36115130-3b4b-43b3-b911-230dae4e6a44.png)
